### PR TITLE
A temporary workaround of executors being used as storage worker

### DIFF
--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -651,7 +651,14 @@ public class Worker {
     healthStatusManager.setStatus(
         HealthStatusManager.SERVICE_NAME_ALL_SERVICES, ServingStatus.SERVING);
     PrometheusPublisher.startHttpServer(configs.getPrometheusPort());
-    startFailsafeRegistration();
+
+    // An executor can also be used as storage worker as scheduler treats all new workers as storage workers
+    // TODO (Congt) Fix it upstream and revert it. 
+    if (configs.getWorker().getCapabilities().isCas()) {
+      startFailsafeRegistration();
+    } else {
+      log.log(INFO, "Skipping worker registration");
+    }
 
     // Listen for pipeline unhandled exceptions
     ExecutorService pipelineExceptionExecutor = newSingleThreadExecutor();


### PR DESCRIPTION
It's introduced by this commit: https://github.com/bazelbuild/bazel-buildfarm/pull/1328

Schedulers subscribe to Redis events and treat all new workers as storage worker. It will cause problem when they tries to upload data to them.