### PR TITLE
Cherry picks two commits to fix the remote cache inefficiency

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -80,6 +80,7 @@ def buildfarm_init(name = "buildfarm"):
                         "com.fasterxml.jackson.core:jackson-databind:2.15.0",
                         "com.github.ben-manes.caffeine:caffeine:2.9.0",
                         "com.github.docker-java:docker-java:3.2.11",
+                        "com.github.fppt:jedis-mock:1.0.10",
                         "com.github.jnr:jffi:1.2.16",
                         "com.github.jnr:jffi:jar:native:1.2.16",
                         "com.github.jnr:jnr-constants:0.9.9",

--- a/src/main/java/build/buildfarm/backplane/Backplane.java
+++ b/src/main/java/build/buildfarm/backplane/Backplane.java
@@ -282,4 +282,7 @@ public interface Backplane {
   Boolean propertiesEligibleForQueue(List<Platform.Property> provisions);
 
   GetClientStartTimeResult getClientStartTime(GetClientStartTimeRequest request) throws IOException;
+
+  /** Set expiry time for digests */
+  void updateDigestsExpiry(Iterable<Digest> digests) throws IOException;
 }

--- a/src/main/java/build/buildfarm/common/redis/RedisMap.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisMap.java
@@ -151,6 +151,25 @@ public class RedisMap {
   }
 
   /**
+   * @brief Get the value of the key and update expiration.
+   * @details If the key does not exist, null is returned.
+   * @param jedis Jedis cluster client.
+   * @param key The name of the key.
+   * @return The value of the key. null if key does not exist.
+   * @note Overloaded.
+   * @note Suggested return identifier: value.
+   */
+  public String getex(JedisCluster jedis, String key, int timeout_s) {
+    // TODO: Cherry-pick https://github.com/buildfarm/buildfarm/pull/2307 after upgrading Jedis to 5.2
+    String keyName = createKeyName(key);
+    String value = jedis.get(keyName);
+    if (value != null) {
+      jedis.expire(keyName, timeout_s);
+    }
+    return value;
+  }
+
+  /**
    * @brief Get the values of the keys.
    * @details If the key does not exist, null is returned.
    * @param jedis Jedis cluster client.

--- a/src/main/java/build/buildfarm/instance/shard/CasWorkerMap.java
+++ b/src/main/java/build/buildfarm/instance/shard/CasWorkerMap.java
@@ -121,4 +121,11 @@ public interface CasWorkerMap {
    * @note Suggested return identifier: mapSize.
    */
   int size(RedisClient client) throws IOException;
+
+  /**
+   * @brief Set the expiry duration for the digests.
+   * @param client Client used for interacting with redis when not using cacheMap.
+   * @param blobDigests The blob digests to set new the expiry duration.
+   */
+  void setExpire(RedisClient client, Iterable<Digest> blobDigests) throws IOException;
 }

--- a/src/main/java/build/buildfarm/instance/shard/JedisCasWorkerMap.java
+++ b/src/main/java/build/buildfarm/instance/shard/JedisCasWorkerMap.java
@@ -234,6 +234,17 @@ public class JedisCasWorkerMap implements CasWorkerMap {
     return client.call(jedis -> ScanCount.get(jedis, name + ":*", 1000));
   }
 
+  @Override
+  public void setExpire(RedisClient client, Iterable<Digest> blobDigests) throws IOException {
+    client.run(
+        jedis -> {
+          for (Digest blobDigest : blobDigests) {
+            String key = redisCasKey(blobDigest);
+            jedis.expire(key, keyExpiration_s);
+          }
+        });
+  }
+
   /**
    * @brief Get the redis key name.
    * @details This is to be used for the direct redis implementation.

--- a/src/main/java/build/buildfarm/instance/shard/JedisCasWorkerMap.java
+++ b/src/main/java/build/buildfarm/instance/shard/JedisCasWorkerMap.java
@@ -173,7 +173,12 @@ public class JedisCasWorkerMap implements CasWorkerMap {
   @Override
   public String getAny(RedisClient client, Digest blobDigest) throws IOException {
     String key = redisCasKey(blobDigest);
-    return client.call(jedis -> jedis.srandmember(key));
+    return client.call(
+      jedis -> {
+        // TODO: Cherry-pick https://github.com/buildfarm/buildfarm/pull/2307 after upgrading Jedis to 5.2
+        jedis.expire(key, keyExpiration_s);
+        return jedis.srandmember(key);
+      });
   }
 
   /**
@@ -187,7 +192,12 @@ public class JedisCasWorkerMap implements CasWorkerMap {
   @Override
   public Set<String> get(RedisClient client, Digest blobDigest) throws IOException {
     String key = redisCasKey(blobDigest);
-    return client.call(jedis -> jedis.smembers(key));
+    return client.call(
+      jedis -> {
+        // TODO: Cherry-pick https://github.com/buildfarm/buildfarm/pull/2307 after upgrading Jedis to 5.2
+        jedis.expire(key, keyExpiration_s);
+        return jedis.smembers(key);
+      });
   }
 
   @Override

--- a/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
@@ -1500,4 +1500,9 @@ public class RedisShardBackplane implements Backplane {
     }
     return GetClientStartTimeResult.newBuilder().addAllClientStartTime(startTimes).build();
   }
+
+  @Override
+  public void updateDigestsExpiry(Iterable<Digest> digests) throws IOException {
+    state.casWorkerMap.setExpire(client, digests);
+  }
 }

--- a/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
@@ -847,7 +847,12 @@ public class RedisShardBackplane implements Backplane {
   @SuppressWarnings("ConstantConditions")
   @Override
   public ActionResult getActionResult(ActionKey actionKey) throws IOException {
-    String json = client.call(jedis -> state.actionCache.get(jedis, asDigestStr(actionKey)));
+    // TODO: Cherry-pick https://github.com/buildfarm/buildfarm/pull/2307 after upgrading Jedis to 5.2
+    String json =
+        client.call(
+            jedis ->
+                state.actionCache.getex(
+                    jedis, asDigestStr(actionKey), configs.getBackplane().getActionCacheExpire()));
     if (json == null) {
       return null;
     }

--- a/src/main/java/build/buildfarm/instance/shard/RedissonCasWorkerMap.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedissonCasWorkerMap.java
@@ -209,6 +209,14 @@ public class RedissonCasWorkerMap implements CasWorkerMap {
     return cacheMap.size();
   }
 
+  @Override
+  public void setExpire(RedisClient client, Iterable<Digest> blobDigests) {
+    for (Digest blobDigest : blobDigests) {
+      String key = cacheMapCasKey(blobDigest);
+      cacheMap.expireKey(key, keyExpiration_s, TimeUnit.SECONDS);
+    }
+  }
+
   /**
    * @brief Get a random element from the set.
    * @details Assumes the set is not empty.

--- a/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
@@ -136,10 +136,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.time.Instant;
+import java.util.AbstractMap;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Deque;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -656,7 +658,7 @@ public class ShardInstance extends AbstractServerInstance {
     }
 
     if (configs.getServer().isFindMissingBlobsViaBackplane()) {
-      return findMissingBlobsViaBackplane(nonEmptyDigests);
+      return findMissingBlobsViaBackplane(nonEmptyDigests, requestMetadata);
     }
 
     return findMissingBlobsQueryingEachWorker(nonEmptyDigests, requestMetadata);
@@ -723,24 +725,40 @@ public class ShardInstance extends AbstractServerInstance {
   // out-of-date and the server lies about which blobs are actually present. We provide this
   // alternative strategy for calculating missing blobs.
   private ListenableFuture<Iterable<Digest>> findMissingBlobsViaBackplane(
-      Iterable<Digest> nonEmptyDigests) {
+      Iterable<Digest> nonEmptyDigests, RequestMetadata requestMetadata) {
     try {
       Set<Digest> uniqueDigests = new HashSet<>();
       nonEmptyDigests.forEach(uniqueDigests::add);
       Map<Digest, Set<String>> foundBlobs = backplane.getBlobDigestsWorkers(uniqueDigests);
       Set<String> workerSet = backplane.getStorageWorkers();
       Map<String, Long> workersStartTime = backplane.getWorkersStartTimeInEpochSecs(workerSet);
-      return immediateFuture(
+      Map<Digest, Set<String>> digestAndWorkersMap =
           uniqueDigests.stream()
-              .filter( // best effort to present digests only missing on active workers
+              .map(
                   digest -> {
                     Set<String> initialWorkers =
                         foundBlobs.getOrDefault(digest, Collections.emptySet());
-                    return filterAndAdjustWorkersForDigest(
-                            digest, initialWorkers, workerSet, workersStartTime)
-                        .isEmpty();
+                    return new AbstractMap.SimpleEntry<>(
+                        digest,
+                        filterAndAdjustWorkersForDigest(
+                            digest, initialWorkers, workerSet, workersStartTime));
                   })
-              .collect(Collectors.toList()));
+              .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+      ListenableFuture<Iterable<Digest>> missingDigestFuture =
+          immediateFuture(
+              digestAndWorkersMap.entrySet().stream()
+                  .filter(entry -> entry.getValue().isEmpty())
+                  .map(Map.Entry::getKey)
+                  .collect(Collectors.toList()));
+      return transformAsync(
+          missingDigestFuture,
+          (missingDigest) -> {
+            extendLeaseForDigests(digestAndWorkersMap, requestMetadata);
+            return immediateFuture(missingDigest);
+          },
+          // Propagate context values but don't cascade its cancellation for downstream calls.
+          Context.current().fork().fixedContextExecutor(directExecutor()));
     } catch (Exception e) {
       log.log(Level.SEVERE, "find missing blob via backplane failed", e);
       return immediateFailedFuture(Status.fromThrowable(e).asException());
@@ -783,6 +801,29 @@ public class ShardInstance extends AbstractServerInstance {
       }
     }
     return workersStartedBeforeDigestInsertion;
+  }
+
+  private void extendLeaseForDigests(
+      Map<Digest, Set<String>> digestAndWorkersMap, RequestMetadata requestMetadata) {
+    Map<String, Set<Digest>> workerAndDigestMap = new HashMap<>();
+    digestAndWorkersMap.forEach(
+        (digest, workers) ->
+            workers.forEach(
+                worker ->
+                    workerAndDigestMap.computeIfAbsent(worker, w -> new HashSet<>()).add(digest)));
+
+    workerAndDigestMap.forEach(
+        (worker, digests) -> workerStub(worker).findMissingBlobs(digests, requestMetadata));
+
+    try {
+      backplane.updateDigestsExpiry(digestAndWorkersMap.keySet());
+    } catch (IOException e) {
+      log.log(
+          Level.WARNING,
+          format(
+              "Failed to update expiry duration for digests (%s) insertion time",
+              digestAndWorkersMap.keySet()));
+    }
   }
 
   private void findMissingBlobsOnWorker(

--- a/src/test/java/build/buildfarm/instance/shard/BUILD
+++ b/src/test/java/build/buildfarm/instance/shard/BUILD
@@ -31,3 +31,22 @@ java_test(
         "@remote_apis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
     ],
 )
+
+java_test(
+    name = "JedisCasWorkerMapTest",
+    size = "small",
+    srcs = [
+        "JedisCasWorkerMapTest.java",
+    ],
+    test_class = "build.buildfarm.AllTests",
+    deps = [
+        "//src/main/java/build/buildfarm/common",
+        "//src/main/java/build/buildfarm/common/redis",
+        "//src/main/java/build/buildfarm/instance/shard",
+        "//src/main/protobuf:build_buildfarm_v1test_buildfarm_java_proto",
+        "//src/test/java/build/buildfarm:test_runner",
+        "//third_party/jedis",
+        "@maven//:com_github_fppt_jedis_mock",
+        "@maven//:com_google_truth_truth",
+    ],
+)

--- a/src/test/java/build/buildfarm/instance/shard/JedisCasWorkerMapTest.java
+++ b/src/test/java/build/buildfarm/instance/shard/JedisCasWorkerMapTest.java
@@ -1,0 +1,63 @@
+package build.buildfarm.instance.shard;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import build.bazel.remote.execution.v2.Digest;
+import build.buildfarm.common.DigestUtil;
+import build.buildfarm.common.redis.RedisClient;
+import com.github.fppt.jedismock.RedisServer;
+import com.github.fppt.jedismock.server.ServiceOptions;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.JedisCluster;
+
+@RunWith(JUnit4.class)
+public class JedisCasWorkerMapTest {
+
+  private static final String CAS_PREFIX = "ContentAddressableStorage";
+
+  private RedisServer redisServer;
+  private RedisClient redisClient;
+  private JedisCasWorkerMap jedisCasWorkerMap;
+
+  @Before
+  public void setup() throws IOException {
+    redisServer =
+        RedisServer.newRedisServer()
+            .setOptions(ServiceOptions.defaultOptions().withClusterModeEnabled())
+            .start();
+    redisClient =
+        new RedisClient(
+            new JedisCluster(
+                Collections.singleton(
+                    new HostAndPort(redisServer.getHost(), redisServer.getBindPort()))));
+    jedisCasWorkerMap = new JedisCasWorkerMap(CAS_PREFIX, 60);
+  }
+
+  @Test
+  public void testSetExpire() throws IOException {
+    Digest testDigest1 = Digest.newBuilder().setHash("abc").build();
+    Digest testDigest2 = Digest.newBuilder().setHash("xyz").build();
+
+    String casKey1 = CAS_PREFIX + ":" + DigestUtil.toString(testDigest1);
+    String casKey2 = CAS_PREFIX + ":" + DigestUtil.toString(testDigest2);
+
+    redisClient.run(jedis -> jedis.sadd(casKey1, "worker1"));
+    jedisCasWorkerMap.setExpire(redisClient, Arrays.asList(testDigest1, testDigest2));
+
+    assertThat((Long) redisClient.call(jedis -> jedis.ttl(casKey1))).isGreaterThan(0L);
+    assertThat((Long) redisClient.call(jedis -> jedis.ttl(casKey2))).isEqualTo(-2L);
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    redisServer.stop();
+  }
+}

--- a/src/test/java/build/buildfarm/instance/shard/ShardInstanceTest.java
+++ b/src/test/java/build/buildfarm/instance/shard/ShardInstanceTest.java
@@ -31,9 +31,13 @@ import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorS
 import static java.util.concurrent.Executors.newSingleThreadExecutor;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.mockito.AdditionalAnswers.answer;
+import static org.mockito.ArgumentMatchers.anyIterable;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
@@ -81,6 +85,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.longrunning.Operation;
 import com.google.protobuf.Any;
@@ -96,6 +101,7 @@ import io.grpc.protobuf.StatusProto;
 import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -1114,8 +1120,12 @@ public class ShardInstanceTest {
     buildfarmConfigs.getServer().setFindMissingBlobsViaBackplane(true);
     Set<String> activeAndImposterWorkers =
         Sets.newHashSet(Iterables.concat(activeWorkers, imposterWorkers));
+
     when(mockBackplane.getStorageWorkers()).thenReturn(activeAndImposterWorkers);
     when(mockBackplane.getBlobDigestsWorkers(any(Iterable.class))).thenReturn(digestAndWorkersMap);
+    when(mockInstanceLoader.load(anyString())).thenReturn(mockWorkerInstance);
+    when(mockWorkerInstance.findMissingBlobs(anyIterable(), any(RequestMetadata.class)))
+        .thenReturn(Futures.immediateFuture(new ArrayList<>()));
 
     long serverStartTime = 1686951033L; // june 15th, 2023
     Map<String, Long> workersStartTime = new HashMap<>();
@@ -1138,6 +1148,10 @@ public class ShardInstanceTest {
         Iterables.concat(missingDigests, digestAvailableOnImposters);
 
     assertThat(actualMissingDigests).containsExactlyElementsIn(expectedMissingDigests);
+    verify(mockWorkerInstance, atMost(3))
+        .findMissingBlobs(anyIterable(), any(RequestMetadata.class));
+    verify(mockWorkerInstance, atLeast(1))
+        .findMissingBlobs(anyIterable(), any(RequestMetadata.class));
 
     for (Digest digest : actualMissingDigests) {
       assertThat(digest).isNotIn(availableDigests);


### PR DESCRIPTION
The ActionCache and CAS on the fork don't update the expiration on read. It caused a lot of unnecessary remote cache expiration and the inefficiency in the remote cache. The problem has been fixed on the latest main. Cherry-pick the fixes before we bump the fork to the latest main.

See 
https://github.com/buildfarm/buildfarm/pull/1455
https://github.com/buildfarm/buildfarm/pull/2307