### PR TITLE
fix: cherry-pick Bazel 9 RBE compatibility fixes from upstream

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -58,6 +58,11 @@ def archive_dependencies(third_party):
             "sha256": "78bf175f9a8fa23cda724bbef52ad9d0d555cdd1122bcb06484b91174f931239",
             "strip_prefix": "grpc-java-1.54.1",
             "urls": ["https://github.com/grpc/grpc-java/archive/v1.54.1.zip"],
+            "patch_args": ["-p1"],
+            "patches": [
+                "%s:grpc-java-12207.patch" % third_party,
+                "%s:grpc-java-12222.patch" % third_party,
+            ],
         },
         {
             "name": "rules_pkg",

--- a/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
+++ b/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
@@ -2775,6 +2775,9 @@ public abstract class CASFileCache implements ContentAddressableStorage {
             onInsert,
             isReset);
     if (out == DUPLICATE_OUTPUT_STREAM) {
+      log.log(Level.FINER, format("duplicate output stream, completing %s for %s", key, writeId));
+      writeWinner.get();
+      onInsert.run();
       return null;
     }
     log.log(Level.FINER, format("entry %s is missing, downloading and populating", key));

--- a/src/main/java/build/buildfarm/common/grpc/StubWriteOutputStream.java
+++ b/src/main/java/build/buildfarm/common/grpc/StubWriteOutputStream.java
@@ -15,6 +15,7 @@
 package build.buildfarm.common.grpc;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static java.lang.String.format;
 import static java.util.logging.Level.WARNING;
@@ -160,12 +161,18 @@ public class StubWriteOutputStream extends FeedbackOutputStream implements Write
       request.setResourceName(resourceName);
     }
     synchronized (this) {
-      writeObserver.onNext(request.build());
+      // writeObserver can be nulled by a completion race
+      // expect that we are completed in this case
+      if (writeObserver != null) {
+        writeObserver.onNext(request.build());
+        wasReset = false;
+        writtenBytes += offset;
+        offset = 0;
+        sentResourceName = true;
+      } else {
+        checkState(writeFuture.isDone(), "writeObserver nulled without completion");
+      }
     }
-    wasReset = false;
-    writtenBytes += offset;
-    offset = 0;
-    sentResourceName = true;
   }
 
   @Override

--- a/src/main/java/build/buildfarm/common/services/WriteStreamObserver.java
+++ b/src/main/java/build/buildfarm/common/services/WriteStreamObserver.java
@@ -268,7 +268,8 @@ public class WriteStreamObserver implements StreamObserver<WriteRequest> {
 
   private boolean errorResponse(Throwable t) {
     if (exception.compareAndSet(null, t)) {
-      if (Status.fromThrowable(t).getCode() == Status.Code.CANCELLED) {
+      if (Status.fromThrowable(t).getCode() == Status.Code.CANCELLED
+          || Context.current().isCancelled()) {
         return false;
       }
       boolean isEntryLimitException = t instanceof EntryLimitException;

--- a/src/main/java/build/buildfarm/common/services/WriteStreamObserver.java
+++ b/src/main/java/build/buildfarm/common/services/WriteStreamObserver.java
@@ -72,6 +72,8 @@ public class WriteStreamObserver implements StreamObserver<WriteRequest> {
   private boolean initialized = false;
   private volatile boolean committed = false;
   private String name = null;
+
+  @GuardedBy("this")
   private Write write = null;
 
   @GuardedBy("this")
@@ -497,7 +499,14 @@ public class WriteStreamObserver implements StreamObserver<WriteRequest> {
   }
 
   @Override
-  public void onCompleted() {
+  public synchronized void onCompleted() {
     log.log(Level.FINER, format("write completed for %s", name));
+    if (write == null) {
+      // we must return with a response lest we emit a grpc warning
+      // there can be no meaningful response at this point, as we
+      // have no idea what the size was
+      responseObserver.onNext(WriteResponse.getDefaultInstance());
+      responseObserver.onCompleted();
+    }
   }
 }

--- a/src/main/java/build/buildfarm/instance/server/AbstractServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/server/AbstractServerInstance.java
@@ -1145,8 +1145,6 @@ public abstract class AbstractServerInstance implements Instance {
       Set<String> inputDirectories,
       Map<Digest, Directory> directoriesIndex,
       PreconditionFailure.Builder preconditionFailure) {
-    validatePlatform(command.getPlatform(), preconditionFailure);
-
     // FIXME should input/output collisions (through directories) be another
     // invalid action?
     filesUniqueAndSortedPrecondition(command.getOutputFilesList(), preconditionFailure);
@@ -1211,6 +1209,13 @@ public abstract class AbstractServerInstance implements Instance {
     ImmutableSet.Builder<String> inputDirectoriesBuilder = ImmutableSet.builder();
     ImmutableSet.Builder<String> inputFilesBuilder = ImmutableSet.builder();
 
+    if (action.hasPlatform()) {
+      // version 2.2: clients SHOULD set these platform properties as well
+      // as those in the [Command][build.bazel.remote.execution.v2.Command]. Servers
+      // SHOULD prefer those set here.
+      validatePlatform(action.getPlatform(), preconditionFailure);
+    }
+
     inputDirectoriesBuilder.add(ACTION_INPUT_ROOT_DIRECTORY_PATH);
     validateActionInputDirectoryDigest(
         ACTION_INPUT_ROOT_DIRECTORY_PATH,
@@ -1230,6 +1235,9 @@ public abstract class AbstractServerInstance implements Instance {
           .setSubject("blobs/" + DigestUtil.toString(action.getCommandDigest()))
           .setDescription(MISSING_COMMAND);
     } else {
+      if (!action.hasPlatform()) {
+        validatePlatform(command.getPlatform(), preconditionFailure);
+      }
       validateCommand(
           command,
           action.getInputRootDigest(),

--- a/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
@@ -1636,6 +1636,15 @@ public class ShardInstance extends AbstractServerInstance {
         .build();
   }
 
+  // version specification: low 2.0, high >= 2.2
+  // Servers SHOULD prefer those set [in Action]
+  private Platform queuedOperationPlatform(QueuedOperation queuedOperation) {
+    if (queuedOperation.getAction().hasPlatform()) {
+      return queuedOperation.getAction().getPlatform();
+    }
+    return queuedOperation.getCommand().getPlatform();
+  }
+
   private ListenableFuture<QueuedOperationResult> uploadQueuedOperation(
       QueuedOperation queuedOperation,
       ExecuteEntry executeEntry,
@@ -1654,7 +1663,7 @@ public class ShardInstance extends AbstractServerInstance {
         QueueEntry.newBuilder()
             .setExecuteEntry(executeEntry)
             .setQueuedOperationDigest(queuedOperationDigest)
-            .setPlatform(queuedOperation.getCommand().getPlatform())
+            .setPlatform(queuedOperationPlatform(queuedOperation))
             .build();
     return transform(
         writeBlobFuture(
@@ -2488,7 +2497,7 @@ public class ShardInstance extends AbstractServerInstance {
                     .setExecuteEntry(executeEntry)
                     .setQueuedOperationDigest(queuedOperationMetadata.getQueuedOperationDigest())
                     .setPlatform(
-                        profiledQueuedMetadata.getQueuedOperation().getCommand().getPlatform())
+                        queuedOperationPlatform(profiledQueuedMetadata.getQueuedOperation()))
                     .build();
             try {
               ensureCanQueue(stopwatch);

--- a/src/main/java/build/buildfarm/server/services/CapabilitiesService.java
+++ b/src/main/java/build/buildfarm/server/services/CapabilitiesService.java
@@ -41,8 +41,9 @@ public class CapabilitiesService extends CapabilitiesGrpc.CapabilitiesImplBase {
         instance
             .getCapabilities()
             .toBuilder()
-            .setLowApiVersion(SemVer.newBuilder().setMajor(2))
-            .setHighApiVersion(SemVer.newBuilder().setMajor(2))
+            .setDeprecatedApiVersion(SemVer.newBuilder().setMajor(2))
+            .setLowApiVersion(SemVer.newBuilder().setMajor(2).setMinor(3))
+            .setHighApiVersion(SemVer.newBuilder().setMajor(2).setMinor(11))
             .build());
     responseObserver.onCompleted();
   }

--- a/src/main/java/build/buildfarm/worker/Executor.java
+++ b/src/main/java/build/buildfarm/worker/Executor.java
@@ -106,7 +106,7 @@ class Executor {
     if (limits.useExecutionPolicies) {
       policies =
           ExecutionPolicies.forPlatform(
-              operationContext.command.getPlatform(), workerContext::getExecutionPolicies);
+              operationContext.queueEntry.getPlatform(), workerContext::getExecutionPolicies);
     }
 
     Operation operation =

--- a/src/main/java/build/buildfarm/worker/shard/RemoteCasWriter.java
+++ b/src/main/java/build/buildfarm/worker/shard/RemoteCasWriter.java
@@ -87,6 +87,7 @@ public class RemoteCasWriter implements CasWriter {
     String workerName = getRandomWorker();
     Write write = getCasMemberWrite(digest, digestFunction, workerName);
 
+    write.reset();
     try {
       return streamIntoWriteFuture(in, write, digest).get();
     } catch (ExecutionException e) {

--- a/src/test/java/build/buildfarm/common/services/WriteStreamObserverTest.java
+++ b/src/test/java/build/buildfarm/common/services/WriteStreamObserverTest.java
@@ -29,6 +29,7 @@ import com.google.protobuf.ByteString;
 import io.grpc.Context;
 import io.grpc.Context.CancellableContext;
 import io.grpc.stub.StreamObserver;
+import java.io.IOException;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import org.junit.Test;
@@ -91,6 +92,53 @@ public class WriteStreamObserverTest {
             any(RequestMetadata.class));
     verify(write, times(1)).getOutput(any(Long.class), any(TimeUnit.class), any(Runnable.class));
     verify(out, times(1)).close();
+    verifyZeroInteractions(responseObserver);
+  }
+
+  @Test
+  public void noErrorWhenContextCancelled() throws Exception {
+    CancellableContext context = Context.current().withCancellation();
+    Instance instance = mock(Instance.class);
+    StreamObserver<WriteResponse> responseObserver = mock(StreamObserver.class);
+    ByteString cancelled = ByteString.copyFromUtf8("cancelled data");
+    Digest cancelledDigest = DIGEST_UTIL.compute(cancelled);
+    UUID uuid = UUID.randomUUID();
+    UploadBlobRequest uploadBlobRequest =
+        UploadBlobRequest.newBuilder()
+            .setBlob(BlobInformation.newBuilder().setDigest(cancelledDigest))
+            .setUuid(uuid.toString())
+            .build();
+    SettableFuture<Long> future = SettableFuture.create();
+    Write write = mock(Write.class);
+    when(write.getFuture()).thenReturn(future);
+    when(write.isComplete()).thenReturn(Boolean.TRUE);
+    when(instance.getBlobWrite(
+            eq(Compressor.Value.IDENTITY),
+            eq(cancelledDigest),
+            eq(uuid),
+            any(RequestMetadata.class)))
+        .thenReturn(write);
+
+    WriteStreamObserver observer =
+        context.call(
+            () -> new WriteStreamObserver(instance, 1, SECONDS, () -> {}, responseObserver));
+    context.run(
+        () ->
+            observer.onNext(
+                WriteRequest.newBuilder()
+                    .setResourceName(uploadResourceName(uploadBlobRequest))
+                    .setData(cancelled)
+                    .build()));
+    context.cancel(new RuntimeException("Cancelled by test"));
+    future.setException(new IOException("test cancel"));
+
+    verify(write, times(1)).isComplete();
+    verify(instance, times(1))
+        .getBlobWrite(
+            eq(Compressor.Value.IDENTITY),
+            eq(cancelledDigest),
+            eq(uuid),
+            any(RequestMetadata.class));
     verifyZeroInteractions(responseObserver);
   }
 }

--- a/third_party/grpc-java-12207.patch
+++ b/third_party/grpc-java-12207.patch
@@ -1,0 +1,66 @@
+commit a37d3eb349e048b953633027ed011cda8b68c603
+Author: George Gensure <werkt0@gmail.com>
+Date:   Thu Jul 10 09:49:54 2025 -0400
+
+    Guarantee missing stream promise delivery
+
+    In observed cases, whether RST_STREAM or another failure from netty or
+    the server, listeners can fail to be notified when a connection yields a
+    null stream for the selected streamId. This causes hangs in clients,
+    despite deadlines, with no obvious resolution.
+
+    Tests which relied upon this promise succeeding must now change.
+
+diff --git a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+index a5fa0f800..276fa623c 100644
+--- a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
++++ b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+@@ -738,14 +738,19 @@ class NettyClientHandler extends AbstractNettyHandler {
+
+                 // Attach the client stream to the HTTP/2 stream object as user data.
+                 stream.setHttp2Stream(http2Stream);
++                promise.setSuccess();
++              } else {
++                // Otherwise, the stream has been cancelled and Netty is sending a
++                // RST_STREAM frame which causes it to purge pending writes from the
++                // flow-controller and delete the http2Stream. The stream listener has already
++                // been notified of cancellation so there is nothing to do.
++                //
++                // This process has been observed to fail in some circumstances, leaving listeners
++                // unanswered. Ensure that some exception has been delivered consistent with the
++                // implied RST_STREAM result above.
++                Status status = Status.INTERNAL.withDescription("unknown stream for connection");
++                promise.setFailure(status.asRuntimeException());
+               }
+-              // Otherwise, the stream has been cancelled and Netty is sending a
+-              // RST_STREAM frame which causes it to purge pending writes from the
+-              // flow-controller and delete the http2Stream. The stream listener has already
+-              // been notified of cancellation so there is nothing to do.
+-
+-              // Just forward on the success status to the original promise.
+-              promise.setSuccess();
+             } else {
+               Throwable cause = future.cause();
+               if (cause instanceof StreamBufferingEncoder.Http2GoAwayException) {
+diff --git a/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java b/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
+index f8fbeea9b..dd4fcb4ea 100644
+--- a/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
++++ b/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
+@@ -268,7 +268,7 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase<NettyClientHand
+     // Cancel the stream.
+     cancelStream(Status.CANCELLED);
+
+-    assertTrue(createFuture.isSuccess());
++    assertFalse(createFuture.isSuccess());
+     verify(streamListener).closed(eq(Status.CANCELLED), same(PROCESSED), any(Metadata.class));
+   }
+
+@@ -311,7 +311,7 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase<NettyClientHand
+     ChannelFuture cancelFuture = cancelStream(Status.CANCELLED);
+     assertTrue(cancelFuture.isSuccess());
+     assertTrue(createFuture.isDone());
+-    assertTrue(createFuture.isSuccess());
++    assertFalse(createFuture.isSuccess());
+   }
+
+   /**

--- a/third_party/grpc-java-12222.patch
+++ b/third_party/grpc-java-12222.patch
@@ -1,0 +1,66 @@
+commit 2e96fbf1e851242f8028af2cbc16dbc96e1037ff
+Author: Eric Anderson <ejona@google.com>
+Date:   Tue Jul 15 15:00:24 2025 -0700
+
+    netty: Associate netty stream eagerly to avoid client hang
+
+    In #12185, RPCs were randomly hanging. In #12207 this was tracked down
+    to the headers promise completing successfully, but the netty stream
+    was null. This was because the headers write hadn't completed but
+    stream.close() had been called by goingAway().
+
+diff --git a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+index 276fa623c..d6bb37904 100644
+--- a/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
++++ b/netty/src/main/java/io/grpc/netty/NettyClientHandler.java
+@@ -773,6 +773,19 @@ class NettyClientHandler extends AbstractNettyHandler {
+             }
+           }
+         });
++    // When the HEADERS are not buffered because of MAX_CONCURRENT_STREAMS in
++    // StreamBufferingEncoder, the stream is created immediately even if the bytes of the HEADERS
++    // are delayed because the OS may have too much buffered and isn't accepting the write. The
++    // write promise is also delayed until flush(). However, we need to associate the netty stream
++    // with the transport state so that goingAway() and forcefulClose() and able to notify the
++    // stream of failures.
++    //
++    // This leaves a hole when MAX_CONCURRENT_STREAMS is reached, as http2Stream will be null, but
++    // it is better than nothing.
++    Http2Stream http2Stream = connection().stream(streamId);
++    if (http2Stream != null) {
++      http2Stream.setProperty(streamKey, stream);
++    }
+   }
+
+   /**
+diff --git a/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java b/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
+index dd4fcb4ea..5a2605eea 100644
+--- a/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
++++ b/netty/src/test/java/io/grpc/netty/NettyClientHandlerTest.java
+@@ -453,6 +453,26 @@ public class NettyClientHandlerTest extends NettyHandlerTestBase<NettyClientHand
+     assertTrue(future.isDone());
+   }
+
++  @Test
++  public void receivedAbruptGoAwayShouldFailRacingQueuedIoStreamid() throws Exception {
++    // Purposefully avoid flush(), since we want the write to not actually complete.
++    // EmbeddedChannel doesn't support flow control, so this is the next closest approximation.
++    ChannelFuture future = channel().write(
++        newCreateStreamCommand(grpcHeaders, streamTransportState));
++    // Read a GOAWAY that indicates our stream can't be sent
++    channelRead(goAwayFrame(0, 0 /* NO_ERROR */, Unpooled.copiedBuffer("this is a test", UTF_8)));
++
++    ArgumentCaptor<Status> captor = ArgumentCaptor.forClass(Status.class);
++    verify(streamListener).closed(captor.capture(), same(REFUSED),
++        ArgumentMatchers.<Metadata>notNull());
++    assertEquals(Status.UNAVAILABLE.getCode(), captor.getValue().getCode());
++    assertEquals(
++        "Abrupt GOAWAY closed sent stream. HTTP/2 error code: NO_ERROR, "
++          + "debug data: this is a test",
++        captor.getValue().getDescription());
++    assertTrue(future.isDone());
++  }
++
+   @Test
+   public void receivedGoAway_shouldFailBufferedStreamsExceedingMaxConcurrentStreams()
+       throws Exception {


### PR DESCRIPTION
## Summary

Cherry-picks critical upstream fixes to resolve sporadic Bazel 9 RBE errors:
- `StatusRuntimeException: UNKNOWN` during ByteStream uploads
- `INTERNAL: RST_STREAM closed stream. HTTP/2 error code: INTERNAL_ERROR` during Execute RPC

### Commits

**Tier 1 - Direct error fixes:**
- **grpc-java RST_STREAM patches** (manual port of upstream `a4fbdad9`): Patches grpc-java 1.54.1 with two fixes from grpc/grpc-java#12207 and grpc/grpc-java#12222 that resolve a longstanding race condition in `NettyClientHandler.createStreamTraced()` causing RST_STREAM/GOAWAY client hangs. First released natively in grpc-java v1.74.0.
- **Check context cancelled before error** (upstream `c4909256`): Prevents UNKNOWN status when a write context is already cancelled/deadline-exceeded.

**Tier 2 - REAPI protocol compliance for Bazel 9:**
- **Capabilities version ranges** (upstream `520751e4`): Reports `deprecated=2.0, low=2.3, high=2.11` instead of `low=2.0, high=2.0` so Bazel 9 clients know what REAPI features the server supports.
- **Prefer Action.platform over Command.platform** (upstream `0d589062`): REAPI v2.2 compliance - Bazel 9 puts Platform in Action, server must read it from there.

**Tier 3 - Additional stability:**
- **Prevent write completion starvation** (upstream `9d3d80aa`): Fixes hang when duplicate output stream is detected.
- **Write cleanups** (upstream `16b3aeaf`): Guards against null write on completion, suppresses noisy cancel logs.