### PR TITLE
fix: cherry-pick Fix Progressive Writes from upstream

### DIFF
--- a/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
+++ b/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
@@ -767,7 +767,6 @@ public abstract class CASFileCache implements ContentAddressableStorage {
       log.log(Level.FINER, format("put: %s", key));
       OutputStream out =
           putImpl(
-              Compressor.Value.IDENTITY,
               key,
               UUID.randomUUID(),
               () -> completeWrite(blob.getDigest()),
@@ -916,6 +915,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
             try {
               if (out != null) {
                 out.cancel();
+                out = null;
               }
             } catch (IOException e) {
               log.log(
@@ -1016,7 +1016,6 @@ public abstract class CASFileCache implements ContentAddressableStorage {
             UniqueWriteOutputStream uniqueOut =
                 createUniqueWriteOutput(
                     out,
-                    key.getCompressor(),
                     key.getDigest(),
                     UUID.fromString(key.getIdentifier()),
                     cancelled -> {
@@ -1028,7 +1027,15 @@ public abstract class CASFileCache implements ContentAddressableStorage {
                     this::isComplete,
                     isReset);
             commitOpenState(uniqueOut.delegate(), outClosedFuture);
-            return uniqueOut;
+            switch (key.getCompressor()) {
+              case IDENTITY:
+                return uniqueOut;
+              case ZSTD:
+                return new ZstdDecompressingOutputStream(uniqueOut);
+              default:
+                throw new UnsupportedOperationException(
+                    "Unsupported compressor " + key.getCompressor());
+            }
           }
 
           private synchronized void syncNotify() {
@@ -1062,7 +1069,6 @@ public abstract class CASFileCache implements ContentAddressableStorage {
 
   UniqueWriteOutputStream createUniqueWriteOutput(
       CancellableOutputStream out,
-      Compressor.Value compressor,
       Digest digest,
       UUID uuid,
       Consumer<Boolean> onClosed,
@@ -1070,7 +1076,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
       boolean isReset)
       throws IOException {
     if (out == null) {
-      out = newOutput(compressor, digest, uuid, isComplete, isReset);
+      out = newOutput(digest, uuid, isComplete, isReset);
     }
     if (out == null) {
       // duplicate output stream
@@ -1099,19 +1105,13 @@ public abstract class CASFileCache implements ContentAddressableStorage {
   }
 
   CancellableOutputStream newOutput(
-      Compressor.Value compressor,
-      Digest digest,
-      UUID uuid,
-      BooleanSupplier isComplete,
-      boolean isReset)
-      throws IOException {
+      Digest digest, UUID uuid, BooleanSupplier isComplete, boolean isReset) throws IOException {
     String key = getKey(digest, false);
     final CancellableOutputStream cancellableOut;
     try {
       log.log(Level.FINER, format("getWrite: %s", key));
       cancellableOut =
           putImpl(
-              compressor,
               key,
               uuid,
               () -> completeWrite(digest),
@@ -2637,7 +2637,6 @@ public abstract class CASFileCache implements ContentAddressableStorage {
     String key = getKey(digest, isExecutable);
     CancellableOutputStream out =
         putImpl(
-            Compressor.Value.IDENTITY, // first place to try internal compression
             key,
             UUID.randomUUID(),
             () -> completeWrite(digest),
@@ -2755,7 +2754,6 @@ public abstract class CASFileCache implements ContentAddressableStorage {
       };
 
   private CancellableOutputStream putImpl(
-      Compressor.Value compressor,
       String key,
       UUID writeId,
       Supplier<Boolean> writeWinner,
@@ -2766,7 +2764,6 @@ public abstract class CASFileCache implements ContentAddressableStorage {
       throws IOException, InterruptedException {
     CancellableOutputStream out =
         putOrReference(
-            compressor,
             key,
             writeId,
             writeWinner,
@@ -2872,7 +2869,6 @@ public abstract class CASFileCache implements ContentAddressableStorage {
   }
 
   private CancellableOutputStream putOrReference(
-      Compressor.Value compressor,
       String key,
       UUID writeId,
       Supplier<Boolean> writeWinner,
@@ -2885,7 +2881,6 @@ public abstract class CASFileCache implements ContentAddressableStorage {
     try {
       CancellableOutputStream out =
           putOrReferenceGuarded(
-              compressor,
               key,
               writeId,
               writeWinner,
@@ -3045,7 +3040,6 @@ public abstract class CASFileCache implements ContentAddressableStorage {
   }
 
   private CancellableOutputStream putOrReferenceGuarded(
-      Compressor.Value compressor,
       String key,
       UUID writeId,
       Supplier<Boolean> writeWinner,
@@ -3086,21 +3080,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
     }
     Supplier<String> hashSupplier = () -> hashOut.hash().toString();
     CountingOutputStream countingOut = new CountingOutputStream(committedSize, hashOut);
-    OutputStream out;
-    boolean direct;
-    switch (compressor) {
-      case IDENTITY:
-        out = countingOut;
-        direct = true;
-        break;
-      case ZSTD:
-        out = new ZstdDecompressingOutputStream(countingOut);
-        direct = false;
-        break;
-      default:
-        throw new UnsupportedOperationException("Unsupported compressor " + compressor);
-    }
-    return new CancellableOutputStream(out) {
+    return new CancellableOutputStream(countingOut) {
       final Digest expectedDigest = keyToDigest(key, blobSizeInBytes, digestUtil);
 
       @Override
@@ -3116,7 +3096,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
         } catch (IOException e) {
           // technically no harm no foul
         }
-        return countingOut.written();
+        return getWritten();
       }
 
       @Override
@@ -3151,15 +3131,11 @@ public abstract class CASFileCache implements ContentAddressableStorage {
       @Override
       public void write(byte[] b, int off, int len) throws IOException {
         long written = getWritten();
-        if (direct && written + len > blobSizeInBytes) {
+        if (written + len > blobSizeInBytes) {
           throw new IOException(
               format("attempted overwrite at %d by %d bytes for %s", written, len, writeKey));
         }
         out.write(b, off, len);
-        if (!direct && getWritten() > blobSizeInBytes) {
-          throw new IOException(
-              format("overwrite at %d by %d bytes for %s", written, len, writeKey));
-        }
       }
 
       @Override

--- a/src/main/java/build/buildfarm/common/grpc/Channels.java
+++ b/src/main/java/build/buildfarm/common/grpc/Channels.java
@@ -14,6 +14,8 @@
 
 package build.buildfarm.common.grpc;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import io.grpc.ManagedChannel;
 import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
@@ -33,8 +35,10 @@ public final class Channels {
       target = target.substring(GRPC_URL_PREFIX.length());
       negotiationType = NegotiationType.PLAINTEXT;
     }
-    NettyChannelBuilder builder =
-        NettyChannelBuilder.forTarget(target).negotiationType(negotiationType);
-    return builder.build();
+    return NettyChannelBuilder.forTarget(target)
+        .negotiationType(negotiationType)
+        .keepAliveTime(300, SECONDS)
+        .keepAliveTimeout(10, SECONDS)
+        .build();
   }
 }

--- a/src/main/java/build/buildfarm/common/grpc/StubWriteOutputStream.java
+++ b/src/main/java/build/buildfarm/common/grpc/StubWriteOutputStream.java
@@ -103,7 +103,8 @@ public class StubWriteOutputStream extends FeedbackOutputStream implements Write
           });
 
   private boolean sentResourceName = false;
-  private int offset = 0;
+  private int bufferOffset = 0;
+  private long offset = 0;
   private long writtenBytes = 0;
 
   @GuardedBy("this")
@@ -134,13 +135,13 @@ public class StubWriteOutputStream extends FeedbackOutputStream implements Write
   public void close() throws IOException {
     if (!checkComplete()) {
       boolean finishWrite = expectedSize == UNLIMITED_EXPECTED_SIZE;
-      if (finishWrite || offset != 0) {
+      if (finishWrite || bufferOffset != 0) {
         initiateWrite();
         flushSome(finishWrite);
       }
       synchronized (this) {
         if (writeObserver != null) {
-          if (finishWrite || getCommittedSize() + offset == expectedSize) {
+          if (finishWrite || getCommittedSize() + bufferOffset == expectedSize) {
             writeObserver.onCompleted();
           } else {
             writeObserver.onError(Status.CANCELLED.asException());
@@ -155,7 +156,7 @@ public class StubWriteOutputStream extends FeedbackOutputStream implements Write
     WriteRequest.Builder request =
         WriteRequest.newBuilder()
             .setWriteOffset(getCommittedSize())
-            .setData(ByteString.copyFrom(buf, 0, offset))
+            .setData(ByteString.copyFrom(buf, 0, bufferOffset))
             .setFinishWrite(finishWrite);
     if (!sentResourceName) {
       request.setResourceName(resourceName);
@@ -166,8 +167,8 @@ public class StubWriteOutputStream extends FeedbackOutputStream implements Write
       if (writeObserver != null) {
         writeObserver.onNext(request.build());
         wasReset = false;
-        writtenBytes += offset;
-        offset = 0;
+        writtenBytes += bufferOffset;
+        bufferOffset = 0;
         sentResourceName = true;
       } else {
         checkState(writeFuture.isDone(), "writeObserver nulled without completion");
@@ -177,9 +178,9 @@ public class StubWriteOutputStream extends FeedbackOutputStream implements Write
 
   @Override
   public void flush() throws IOException {
-    if (!checkComplete() && offset != 0) {
+    if (!checkComplete() && bufferOffset != 0) {
       initiateWrite();
-      flushSome(getCommittedSize() + offset == expectedSize);
+      flushSome(getCommittedSize() + bufferOffset == expectedSize);
     }
   }
 
@@ -234,6 +235,16 @@ public class StubWriteOutputStream extends FeedbackOutputStream implements Write
 
                     @Override
                     public void onError(Throwable t) {
+                      if (Status.fromThrowable(t).getCode() != Code.CANCELLED) {
+                        log.log(
+                            WARNING,
+                            format(
+                                "%s: write(%s) on worker %s after %d bytes of content",
+                                Status.fromThrowable(t).getCode().name(),
+                                resourceName,
+                                bsStub.get().getChannel().authority(),
+                                getCommittedSize()));
+                      }
                       writeFuture.setException(exceptionTranslator.apply(t));
                     }
 
@@ -252,18 +263,18 @@ public class StubWriteOutputStream extends FeedbackOutputStream implements Write
     if (isComplete()) {
       throw new WriteCompleteException();
     }
-    if (getCommittedSize() + offset + len > expectedSize) {
+    if (getCommittedSize() + bufferOffset + len > expectedSize) {
       throw new IndexOutOfBoundsException("write would exceed expected size");
     }
     boolean lastFlushed = false;
     while (len > 0 && !checkComplete()) {
       lastFlushed = false;
-      int copyLen = Math.min(buf.length - offset, len);
-      System.arraycopy(b, off, buf, offset, copyLen);
-      offset += copyLen;
+      int copyLen = Math.min(buf.length - bufferOffset, len);
+      System.arraycopy(b, off, buf, bufferOffset, copyLen);
+      bufferOffset += copyLen;
       off += copyLen;
       len -= copyLen;
-      if (offset == buf.length || getCommittedSize() + offset == expectedSize) {
+      if (bufferOffset == buf.length || getCommittedSize() + bufferOffset == expectedSize) {
         flush();
         lastFlushed = true;
       }
@@ -279,8 +290,8 @@ public class StubWriteOutputStream extends FeedbackOutputStream implements Write
       throw new WriteCompleteException();
     }
     if (!checkComplete()) {
-      buf[offset++] = (byte) b;
-      if (autoflush || offset == buf.length) {
+      buf[bufferOffset++] = (byte) b;
+      if (autoflush || bufferOffset == buf.length) {
         flush();
       }
     }
@@ -333,6 +344,9 @@ public class StubWriteOutputStream extends FeedbackOutputStream implements Write
     this.deadlineAfter = deadlineAfter;
     this.deadlineAfterUnits = deadlineAfterUnits;
     this.onReadyHandler = onReadyHandler;
+    this.bufferOffset = 0;
+    writtenBytes = 0;
+    wasReset = true;
     synchronized (this) {
       if (writeObserver == null) {
         initiateWrite();
@@ -351,8 +365,9 @@ public class StubWriteOutputStream extends FeedbackOutputStream implements Write
   public void reset() {
     if (!writeFuture.isDone()) {
       wasReset = true;
-      offset = 0;
+      bufferOffset = 0;
       writtenBytes = 0;
+      offset = 0;
     }
   }
 

--- a/src/main/java/build/buildfarm/common/services/WriteStreamObserver.java
+++ b/src/main/java/build/buildfarm/common/services/WriteStreamObserver.java
@@ -371,6 +371,7 @@ public class WriteStreamObserver implements StreamObserver<WriteRequest> {
     } else {
       if (offset == 0 && offset != committedSize) {
         write.reset();
+        out = null;
         committedSize = 0;
       }
       if (earliestOffset < 0 || offset < earliestOffset) {
@@ -384,8 +385,12 @@ public class WriteStreamObserver implements StreamObserver<WriteRequest> {
       if (bytesToWrite == 0 || committedSize - offset >= bytesToWrite) {
         requestNextIfReady();
       } else {
-        // constrained to be within bytesToWrite
-        bytesToWrite -= (int) (committedSize - offset);
+        // committed size is nonsense for compressed streams. Uncompressed + Compressed in
+        // sequence
+        if (compressor == Compressor.Value.IDENTITY) {
+          // constrained to be within bytesToWrite
+          bytesToWrite -= (int) (committedSize - offset);
+        }
         int skipBytes = data.size() - bytesToWrite;
         if (skipBytes != 0) {
           data = data.substring(skipBytes);

--- a/src/main/java/build/buildfarm/instance/shard/RemoteInputStreamFactory.java
+++ b/src/main/java/build/buildfarm/instance/shard/RemoteInputStreamFactory.java
@@ -31,6 +31,7 @@ import build.buildfarm.common.DigestUtil;
 import build.buildfarm.common.InputStreamFactory;
 import build.buildfarm.instance.Instance;
 import build.buildfarm.instance.shard.ShardInstance.WorkersCallback;
+import build.buildfarm.instance.stub.StubInstance;
 import com.google.common.base.Throwables;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.Iterables;
@@ -64,13 +65,13 @@ public class RemoteInputStreamFactory implements InputStreamFactory {
   private final @Nullable String publicName;
   private final Backplane backplane;
   private final Random rand;
-  private final LoadingCache<String, Instance> workerStubs;
+  private final LoadingCache<String, StubInstance> workerStubs;
   private final UnavailableConsumer onUnavailable;
 
   RemoteInputStreamFactory(
       Backplane backplane,
       Random rand,
-      LoadingCache<String, Instance> workerStubs,
+      LoadingCache<String, StubInstance> workerStubs,
       UnavailableConsumer onUnavailable) {
     this(/* publicName=*/ null, backplane, rand, workerStubs, onUnavailable);
   }
@@ -80,7 +81,7 @@ public class RemoteInputStreamFactory implements InputStreamFactory {
       String publicName,
       Backplane backplane,
       Random rand,
-      LoadingCache<String, Instance> workerStubs,
+      LoadingCache<String, StubInstance> workerStubs,
       UnavailableConsumer onUnavailable) {
     this.publicName = publicName;
     this.backplane = backplane;
@@ -91,7 +92,9 @@ public class RemoteInputStreamFactory implements InputStreamFactory {
 
   private Instance workerStub(String worker) {
     try {
-      return workerStubs.get(worker);
+      StubInstance stubInstance = workerStubs.get(worker);
+      stubInstance.setOnStopped(() -> workerStubs.invalidate(worker));
+      return stubInstance;
     } catch (ExecutionException e) {
       log.log(Level.SEVERE, String.format("error getting worker stub for %s", worker), e);
       throw new IllegalStateException("stub instance creation must not fail");

--- a/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
@@ -81,6 +81,7 @@ import build.buildfarm.common.grpc.UniformDelegateServerCallStreamObserver;
 import build.buildfarm.instance.Instance;
 import build.buildfarm.instance.MatchListener;
 import build.buildfarm.instance.server.AbstractServerInstance;
+import build.buildfarm.instance.stub.StubInstance;
 import build.buildfarm.operations.EnrichedOperation;
 import build.buildfarm.operations.FindOperationsResults;
 import build.buildfarm.v1test.BackplaneStatus;
@@ -225,7 +226,7 @@ public class ShardInstance extends AbstractServerInstance {
   private final Backplane backplane;
   private final ActionCache actionCache;
   private final RemoteInputStreamFactory remoteInputStreamFactory;
-  private final com.google.common.cache.LoadingCache<String, Instance> workerStubs;
+  private final com.google.common.cache.LoadingCache<String, StubInstance> workerStubs;
   private final Thread dispatchedMonitor;
   private final Duration maxActionTimeout;
   private AsyncCache<Digest, Directory> directoryCache;
@@ -341,7 +342,7 @@ public class ShardInstance extends AbstractServerInstance {
       Duration maxActionTimeout,
       boolean useDenyList,
       Runnable onStop,
-      LoadingCache<String, Instance> workerStubs,
+      LoadingCache<String, StubInstance> workerStubs,
       ListeningExecutorService actionCacheFetchService,
       boolean ensureOutputsPresent) {
     super(
@@ -1279,7 +1280,9 @@ public class ShardInstance extends AbstractServerInstance {
 
   private Instance workerStub(String worker) {
     try {
-      return workerStubs.get(worker);
+      StubInstance stubInstance = workerStubs.get(worker);
+      stubInstance.setOnStopped(() -> workerStubs.invalidate(worker));
+      return stubInstance;
     } catch (ExecutionException e) {
       log.log(Level.SEVERE, "error getting worker stub for " + worker, e);
       throw new IllegalStateException("stub instance creation must not fail");

--- a/src/main/java/build/buildfarm/instance/shard/WorkerStubs.java
+++ b/src/main/java/build/buildfarm/instance/shard/WorkerStubs.java
@@ -15,6 +15,7 @@
 package build.buildfarm.instance.shard;
 
 import static build.buildfarm.common.grpc.Channels.createChannel;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static com.google.common.util.concurrent.MoreExecutors.listeningDecorator;
 import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
 
@@ -26,41 +27,75 @@ import build.buildfarm.instance.stub.StubInstance;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
-import com.google.common.cache.RemovalListener;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
+import com.google.common.util.concurrent.SettableFuture;
 import com.google.protobuf.Duration;
+import io.grpc.ConnectivityState;
+import io.grpc.ManagedChannel;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public final class WorkerStubs {
   private WorkerStubs() {}
 
-  @SuppressWarnings("rawtypes")
-  public static LoadingCache create(DigestUtil digestUtil, Duration timeout) {
+  public static LoadingCache<String, StubInstance> create(DigestUtil digestUtil, Duration timeout) {
     return CacheBuilder.newBuilder()
         .expireAfterAccess(10, TimeUnit.MINUTES)
-        .removalListener(
-            (RemovalListener<String, Instance>)
-                notification -> stopInstance(notification.getValue()))
         .build(
-            new CacheLoader<String, Instance>() {
+            new CacheLoader<String, StubInstance>() {
               @SuppressWarnings("NullableProblems")
               @Override
-              public Instance load(String worker) {
+              public StubInstance load(String worker) {
                 return newStubInstance(worker, digestUtil, timeout);
               }
             });
   }
 
-  private static Instance newStubInstance(String worker, DigestUtil digestUtil, Duration timeout) {
-    return new StubInstance(
-        "",
-        worker,
-        digestUtil,
-        createChannel(worker),
-        createChannel(worker), // separate write channel
-        timeout,
-        newStubRetrier(),
-        newStubRetryService());
+  private static ManagedChannel createMonitoredChannel(
+      String worker, AtomicInteger active, Runnable onAllIdle) {
+    ManagedChannel channel = createChannel(worker);
+    channel.notifyWhenStateChanged(
+        channel.getState(/* requestConnection= */ false),
+        new Runnable() {
+          boolean wasIdle = false;
+
+          @Override
+          public void run() {
+            ConnectivityState state = channel.getState(/* requestConnection= */ false);
+            if (state == ConnectivityState.IDLE) {
+              if (active.decrementAndGet() == 0) {
+                onAllIdle.run();
+              }
+              wasIdle = true;
+            } else if (wasIdle) {
+              wasIdle = false;
+              active.incrementAndGet();
+            }
+            channel.notifyWhenStateChanged(state, this);
+          }
+        });
+    return channel;
+  }
+
+  private static StubInstance newStubInstance(
+      String worker, DigestUtil digestUtil, Duration timeout) {
+    AtomicInteger active = new AtomicInteger(2); // one for each channel
+    SettableFuture<Void> idle = SettableFuture.create();
+    Runnable onAllIdle = () -> idle.set(null);
+    ManagedChannel channel = createMonitoredChannel(worker, active, onAllIdle);
+    ManagedChannel writeChannel = createMonitoredChannel(worker, active, onAllIdle);
+    StubInstance instance =
+        new StubInstance(
+            "",
+            worker,
+            digestUtil,
+            channel,
+            writeChannel, // separate write channel
+            timeout,
+            newStubRetrier(),
+            newStubRetryService());
+    idle.addListener(() -> stopInstance(instance), directExecutor());
+    return instance;
   }
 
   private static Retrier newStubRetrier() {

--- a/src/main/java/build/buildfarm/instance/stub/StubInstance.java
+++ b/src/main/java/build/buildfarm/instance/stub/StubInstance.java
@@ -166,6 +166,10 @@ public class StubInstance implements Instance {
   private final Retrier retrier;
   private final @Nullable ListeningScheduledExecutorService retryService;
   private boolean isStopped = false;
+
+  @GuardedBy("this")
+  private Runnable onStopped;
+
   private final long maxBatchUpdateBlobsSize = Size.mbToBytes(3);
 
   @VisibleForTesting long maxRequestSize = Size.mbToBytes(4);
@@ -221,6 +225,16 @@ public class StubInstance implements Instance {
 
   public Channel getChannel() {
     return channel;
+  }
+
+  public void setOnStopped(Runnable onStopped) {
+    if (isStopped) {
+      onStopped.run();
+    } else {
+      synchronized (this) {
+        this.onStopped = onStopped;
+      }
+    }
   }
 
   // no deadline for this
@@ -384,6 +398,14 @@ public class StubInstance implements Instance {
     if (retryService != null && !shutdownAndAwaitTermination(retryService, 10, TimeUnit.SECONDS)) {
       log.log(Level.SEVERE, format("Could not shut down retry service for %s", identifier));
     }
+    Runnable onStopped = () -> {};
+    synchronized (this) {
+      if (this.onStopped != null) {
+        onStopped = this.onStopped;
+        this.onStopped = null;
+      }
+    }
+    onStopped.run();
   }
 
   private void throwIfStopped() {

--- a/src/main/java/build/buildfarm/worker/shard/BUILD
+++ b/src/main/java/build/buildfarm/worker/shard/BUILD
@@ -15,6 +15,7 @@ java_library(
         "//src/main/java/build/buildfarm/instance",
         "//src/main/java/build/buildfarm/instance/server",
         "//src/main/java/build/buildfarm/instance/shard",
+        "//src/main/java/build/buildfarm/instance/stub",
         "//src/main/java/build/buildfarm/metrics/prometheus",
         "//src/main/java/build/buildfarm/operations",
         "//src/main/java/build/buildfarm/worker",

--- a/src/main/java/build/buildfarm/worker/shard/RemoteCasWriter.java
+++ b/src/main/java/build/buildfarm/worker/shard/RemoteCasWriter.java
@@ -28,6 +28,7 @@ import build.buildfarm.common.grpc.Retrier;
 import build.buildfarm.common.grpc.RetryException;
 import build.buildfarm.common.io.FeedbackOutputStream;
 import build.buildfarm.instance.Instance;
+import build.buildfarm.instance.stub.StubInstance;
 import com.google.common.base.Throwables;
 import com.google.common.cache.LoadingCache;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -51,11 +52,11 @@ import lombok.extern.java.Log;
 @Log
 public class RemoteCasWriter implements CasWriter {
   private final Set<String> workerSet;
-  private final LoadingCache<String, Instance> workerStubs;
+  private final LoadingCache<String, StubInstance> workerStubs;
   private final Retrier retrier;
 
   public RemoteCasWriter(
-      Set<String> workerSet, LoadingCache<String, Instance> workerStubs, Retrier retrier) {
+      Set<String> workerSet, LoadingCache<String, StubInstance> workerStubs, Retrier retrier) {
     this.workerSet = workerSet;
     this.workerStubs = workerStubs;
     this.retrier = retrier;
@@ -147,7 +148,9 @@ public class RemoteCasWriter implements CasWriter {
 
   private Instance workerStub(String worker) {
     try {
-      return workerStubs.get(worker);
+      StubInstance stubInstance = workerStubs.get(worker);
+      stubInstance.setOnStopped(() -> workerStubs.invalidate(worker));
+      return stubInstance;
     } catch (ExecutionException e) {
       log.log(Level.SEVERE, "error getting worker stub for " + worker, e.getCause());
       throw new IllegalStateException("stub instance creation must not fail");

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -48,6 +48,7 @@ import build.buildfarm.instance.Instance;
 import build.buildfarm.instance.shard.RedisShardBackplane;
 import build.buildfarm.instance.shard.RemoteInputStreamFactory;
 import build.buildfarm.instance.shard.WorkerStubs;
+import build.buildfarm.instance.stub.StubInstance;
 import build.buildfarm.metrics.prometheus.PrometheusPublisher;
 import build.buildfarm.v1test.ShardWorker;
 import build.buildfarm.worker.ExecuteActionStage;
@@ -143,7 +144,7 @@ public class Worker {
   private ExecFileSystem execFileSystem;
   private Pipeline pipeline;
   private Backplane backplane;
-  private LoadingCache<String, Instance> workerStubs;
+  private LoadingCache<String, StubInstance> workerStubs;
 
   @Autowired private ApplicationContext springContext;
   /**

--- a/src/test/java/build/buildfarm/common/grpc/StubWriteOutputStreamTest.java
+++ b/src/test/java/build/buildfarm/common/grpc/StubWriteOutputStreamTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import com.google.bytestream.ByteStreamGrpc;
 import com.google.bytestream.ByteStreamGrpc.ByteStreamImplBase;
@@ -191,5 +192,40 @@ public class StubWriteOutputStreamTest {
       callbackTimedOut = true;
     }
     assertThat(callbackTimedOut).isTrue();
+  }
+
+  @Test
+  public void getOutputOffsetMatchesCommittedSize() {
+    StreamObserver<WriteRequest> writeObserver = mock(StreamObserver.class);
+    serviceRegistry.addService(
+        new ByteStreamImplBase() {
+          @Override
+          public void queryWriteStatus(
+              QueryWriteStatusRequest request,
+              StreamObserver<QueryWriteStatusResponse> responseObserver) {
+            responseObserver.onNext(
+                QueryWriteStatusResponse.newBuilder().setCommittedSize(20).build());
+            responseObserver.onCompleted();
+          }
+
+          @Override
+          public StreamObserver<WriteRequest> write(
+              StreamObserver<WriteResponse> responseObserver) {
+            return writeObserver;
+          }
+        });
+    String resourceName = "resumed-resource";
+    StubWriteOutputStream write =
+        new StubWriteOutputStream(
+            Suppliers.ofInstance(ByteStreamGrpc.newBlockingStub(channel)),
+            Suppliers.ofInstance(ByteStreamGrpc.newStub(channel)),
+            resourceName,
+            e -> e,
+            /* expectedSize= */ 40,
+            /* autoflush= */ false);
+
+    write.getOutput(20, 1, SECONDS, () -> {});
+    assertThat(write.getCommittedSize()).isEqualTo(20);
+    verifyNoInteractions(writeObserver);
   }
 }

--- a/src/test/java/build/buildfarm/instance/shard/BUILD
+++ b/src/test/java/build/buildfarm/instance/shard/BUILD
@@ -12,6 +12,7 @@ java_test(
         "//src/main/java/build/buildfarm/instance",
         "//src/main/java/build/buildfarm/instance/server",
         "//src/main/java/build/buildfarm/instance/shard",
+        "//src/main/java/build/buildfarm/instance/stub",
         "//src/main/protobuf:build_buildfarm_v1test_buildfarm_java_proto",
         "//src/test/java/build/buildfarm:test_runner",
         "//third_party/jedis",

--- a/src/test/java/build/buildfarm/instance/shard/ShardInstanceTest.java
+++ b/src/test/java/build/buildfarm/instance/shard/ShardInstanceTest.java
@@ -72,6 +72,7 @@ import build.buildfarm.common.Watcher;
 import build.buildfarm.common.Write.NullWrite;
 import build.buildfarm.common.config.BuildfarmConfigs;
 import build.buildfarm.instance.Instance;
+import build.buildfarm.instance.stub.StubInstance;
 import build.buildfarm.v1test.CompletedOperationMetadata;
 import build.buildfarm.v1test.ExecuteEntry;
 import build.buildfarm.v1test.QueueEntry;
@@ -142,9 +143,9 @@ public class ShardInstanceTest {
 
   @Mock private Runnable mockOnStop;
 
-  @Mock private CacheLoader<String, Instance> mockInstanceLoader;
+  @Mock private CacheLoader<String, StubInstance> mockInstanceLoader;
 
-  @Mock Instance mockWorkerInstance;
+  @Mock StubInstance mockWorkerInstance;
 
   @Before
   public void setUp() throws InterruptedException {


### PR DESCRIPTION
## Summary
- Cherry-pick of upstream [da191bc5](https://github.com/bazelbuild/bazel-buildfarm/commit/da191bc5) ("Fix Progressive Writes") with conflict resolution for the fork
- Fixes zstd-compressed blob uploads stalling on write retry/resume, causing 600s scheduler hang and ALB 502
- Root cause confirmed via ALB access logs: `ByteStream/Write` requests hanging for exactly 600s with `target_processing_time=600.001` before ALB kills with 502

### What the fix does
- Nulls `out` after `write.reset()` in `WriteStreamObserver` so a fresh zstd decompressor is created on retry
- Skips `bytesToWrite` adjustment for compressed streams where committed size math is nonsensical
- Nulls `out` after `out.cancel()` in `CASFileCache.Write.reset()` to prevent stale decompressor reuse
- Renames `offset` to `bufferOffset` in `StubWriteOutputStream` to properly track buffer position vs stream offset

### Evidence
- Scheduler logs: `error uploads/.../compressed-blobs/zstd/blake3/.../390518560 after 7 requests and 114688 bytes at offset 28609097`
- ALB logs: `502` with `target_processing_time=600.001` on `ByteStream/Write`
- Storage worker logs: `error writing data` with `0 requests and 0 bytes at offset 28609097` (retries receiving nothing)